### PR TITLE
Fix apt misunderstand // Installing before updating

### DIFF
--- a/ideas/ideas3_06.ipynb
+++ b/ideas/ideas3_06.ipynb
@@ -230,22 +230,11 @@
       "cell_type": "code",
       "source": [
         "# La instalación puede tardar algo más de un minuto\n",
+        "!apt update\n",
         "!apt install octave"
       ],
       "metadata": {
         "id": "a57wWV1JQ-OX"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# opcionalmene podemos actualizar los paquetes\n",
-        "!apt update"
-      ],
-      "metadata": {
-        "id": "7XdWRPpDRQqv"
       },
       "execution_count": null,
       "outputs": []

--- a/ideas/ideas3_08.ipynb
+++ b/ideas/ideas3_08.ipynb
@@ -72,8 +72,8 @@
     {
       "cell_type": "code",
       "source": [
-        "!apt install octave\n",
-        "!apt update"
+        "!apt update\n",
+        "!apt install octave"
       ],
       "metadata": {
         "id": "ZNmjQ_kL_QZi"

--- a/ideas/ideas3_09.ipynb
+++ b/ideas/ideas3_09.ipynb
@@ -109,8 +109,8 @@
     {
       "cell_type": "code",
       "source": [
-        "!apt install octave\n",
-        "!apt update"
+        "!apt update\n",
+        "!apt install octave"
       ],
       "metadata": {
         "id": "KTSEltv2xr2f"


### PR DESCRIPTION
# Fix apt misunderstand // Installing before updating

## TL;DR

Se estaba haciendo el `update` después de la instalación de los paquetes, por lo que esta acción quedaba sin efecto. Es necesario invertir el orden de estos comandos.

## Detalles 

Si nos remitimos a la [documentación oficial](https://manpages.ubuntu.com/manpages/xenial/man8/apt.8.html):
  * **update** is used to download package information from all configured sources. Other commands operate on this data to e.g. perform package upgrades or search in and display details about all packages available for installation.
  * **install** performs the requested action on one or more packages specified [...]
  * **upgrade** is used to install available upgrades of all packages currently installed on the system from the sources [...].

Por tanto, el orden correcto es: 
 1. **update**: me descargo la información de los paquetes disponible en los repositorios. Entre esta información se encuentra la última versión disponible para una versión dada, que puede ser más reciente que en la copia local que de esta información que tengo en mi equipo; 
 2. **install**: salvo que se indique una versión en concreto, me descargo la última versión del paquete, o paquetes, localizando cuál es esta última versión "mirando" en mi copia local de los repositorios. La última versión de la copia local de mis repositorios, descargada con el _update_, puede ser distinta a la última versión disponible en los repositorios; 
 3. Con el tiempo y en caso de ser necesario, ejecuto un **upgrade** para instalar actualizaciones de los paquetes indicados (al igual que en el install, no "veré" nuevas versiones de los paquetes si no he hecho recientemente un update, puesto que trabajaré con mi copia local antigua).

Nótese que, si bien es altamente recomendable y una muy buena práctica, no siempre es necesario hacer el `update`. Puede ser omitido si, por ejemplo, hemos hecho recientemente la misma operación y/o sabemos que nuestro caso de uso se soluciona con la versión disponible en el anterior `update`. 